### PR TITLE
Add UpliftAI key to CI tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -95,6 +95,7 @@ jobs:
       GOOGLE_SA_FILE_B64: ${{ secrets.GOOGLE_SA_FILE_B64 }}
       PLAYHT_API_KEY: ${{ secrets.PLAYHT_API_KEY }}
       PLAYHT_USER_ID: ${{ secrets.PLAYHT_USER_ID }}
+      UPLIFTAI_KEY: ${{ secrets.UPLIFTAI_KEY }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Instructions for Contributors
+
+- Use [`uv`](https://github.com/astral-sh/uv) for dependency management.
+  Install all extras with:
+  
+  ```bash
+  uv sync --all-extras
+  ```
+
+- Run tests with:
+  
+  ```bash
+  uv run pytest -m "not synthetic and not sapi and not watson"
+  ```
+
+- The test suite requires credentials for several TTS engines. Provide
+  the necessary environment variables or a `credentials.json` file as
+  described in `tests/load_credentials.py`.
+
+- When new engines require credentials, ensure corresponding secrets are
+  added to the GitHub Actions workflow environment variables.


### PR DESCRIPTION
## Summary
- expose `UPLIFTAI_KEY` to the test workflow
- document development workflow in `AGENTS.md`

## Testing
- `uv sync --all-extras`
- `uv run postinstall`
- `POLLY_REGION=dummy POLLY_AWS_KEY_ID=dummy POLLY_AWS_ACCESS_KEY=dummy GOOGLE_SA_PATH=google_creds.json GOOGLE_SA_FILE_B64=e30= MICROSOFT_TOKEN=dummy MICROSOFT_REGION=dummy WATSON_API_KEY=dummy WATSON_REGION=dummy WATSON_INSTANCE_ID=dummy ELEVENLABS_API_KEY=dummy WITAI_TOKEN=dummy PLAYHT_API_KEY=dummy PLAYHT_USER_ID=dummy UPLIFTAI_KEY=dummy uv run pytest -m "not synthetic and not sapi and not watson"`


------
https://chatgpt.com/codex/tasks/task_e_68ab73b9fa748327919964aea380d217